### PR TITLE
Add logging setup and `--verbose` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ v0.3.0 (in development)
 - Added a short `-R` form for `--root`
 - Added `--stash` option to `run` command
 - Added `--label` and `--soft-label` options to the `run-pr` command
+- Added `--verbose` option
 
 v0.2.0 (2025-01-06)
 -------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ v0.3.0 (in development)
 - Added a short `-R` form for `--root`
 - Added `--stash` option to `run` command
 - Added `--label` and `--soft-label` options to the `run-pr` command
+- Log executed external commands and HTTP requests
 - Added `--verbose` option
+- `--quiet` can now be specified twice to suppress output from `run` and
+  `runpr` commands
 
 v0.2.0 (2025-01-06)
 -------------------

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,6 +241,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fern"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4316185f709b23713e41e3195f90edef7fb00c3ed4adc79769cf09cc762a3b29"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,10 +274,12 @@ dependencies = [
  "anyhow",
  "cargo_metadata",
  "clap",
+ "fern",
  "fs-err",
  "gh-token",
  "ghrepo",
  "indenter",
+ "log",
  "mime",
  "parse_link_header",
  "rand",
@@ -577,9 +588,9 @@ checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "memchr"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,15 +241,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fern"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4316185f709b23713e41e3195f90edef7fb00c3ed4adc79769cf09cc762a3b29"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "flate2"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,12 +265,10 @@ dependencies = [
  "anyhow",
  "cargo_metadata",
  "clap",
- "fern",
  "fs-err",
  "gh-token",
  "ghrepo",
  "indenter",
- "log",
  "mime",
  "parse_link_header",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,12 @@ anstyle = "1.0.10"
 anyhow = "1.0.94"
 cargo_metadata = "0.19.1"
 clap = { version = "4.5.23", default-features = false, features = ["derive", "error-context", "help", "std", "suggestions", "usage", "wrap_help"] }
+fern = "0.7.1"
 fs-err = "3.0.0"
 gh-token = "0.1.7"
 ghrepo = { version = "0.7.0", features = ["serde"] }
 indenter = "0.3.3"
+log = "0.4.25"
 mime = "0.3.17"
 parse_link_header = { version = "0.4.0", features = ["url"] }
 rand = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,10 @@ anstyle = "1.0.10"
 anyhow = "1.0.94"
 cargo_metadata = "0.19.1"
 clap = { version = "4.5.23", default-features = false, features = ["derive", "error-context", "help", "std", "suggestions", "usage", "wrap_help"] }
-fern = "0.7.1"
 fs-err = "3.0.0"
 gh-token = "0.1.7"
 ghrepo = { version = "0.7.0", features = ["serde"] }
 indenter = "0.3.3"
-log = "0.4.25"
 mime = "0.3.17"
 parse_link_header = { version = "0.4.0", features = ["url"] }
 rand = "0.9.0"

--- a/README.md
+++ b/README.md
@@ -56,14 +56,60 @@ subcommand.
   will instead continue with the remaining projects and will print a list of
   all failures on exit.
 
-- `-q`, `--quiet` — Suppress successful command output
+- `-q`, `--quiet` — Be less verbose; this option can be specified multiple
+  times.  See "Logging" below for more infomation.
 
-- `-R <dirpath>`, `--root <dirpath>` — Start traversing from `<dirpath>`.  Can
-  be specified multiple times to traverse multiple directories.  [default: the
-  current working directory]
+- `-R <dirpath>`, `--root <dirpath>` — Start traversing from `<dirpath>`.  This
+  option can be specified multiple times to traverse multiple directories.
+  [default: the current working directory]
 
 - `--skip <name>` — Do not operate on the given project.  This option can be
   specified multiple times.
+
+- `-v`, `--verbose` — Be more verbose.  See "Logging" below for more
+  information.
+
+Logging
+-------
+
+`forall` logs various messages to stdout and/or stderr during its operation.
+The `-q`/`--quiet` and `-v`/`--verbose` options can be used to control which
+messages are shown.  The following table indicates when each type of message is
+shown for each quiet/verbose level:
+
+| Message Type                      | `-qq` | `-q` |  —  | `-v` | Style  | Stream |
+| --------------------------------- | :---: | :--: | :-: | :--: | ------ | ------ |
+| Project names                     | ✓     | ✓    | ✓   | ✓    | Bold   | stdout |
+| Errors                            | ✓     | ✓    | ✓   | ✓    | Red    | stderr |
+| `run` and `runpr` commands        | ✗     | ✗    | ✓   | ✓    | Cyan   | stderr |
+| `run` and `runpr` commands output | ✗     | ✓    | ✓   | ✓    | Plain  | stdout |
+| Operational commands              | ✗     | ✗    | ✓   | ✓    | Cyan   | stderr |
+| Operational commands output       | ✗     | ✗    | ✓   | ✓    | Plain  | stdout |
+| Filter commands                   | ✗     | ✗    | ✗   | ✓    | Cyan   | stderr |
+| Filter commands output            | ✗     | ✗    | ✗   | ✗    | —      | —      |
+| HTTP requests                     | ✗     | ✗    | ✗   | ✓    | Cyan   | stderr |
+| Messages about skipped projects   | ✗     | ✗    | ✗   | ✓    | Yellow | stderr |
+| Other informative messages        | ✗     | ✗    | ✓   | ✓    | Yellow | stderr |
+
+Notes:
+
+- If both `--quiet` and `--verbose` are specified on the command line, the
+  `--verbose` negates one instance of `--quiet`.
+
+- Passing more than two `--quiet` options (after applying `--verbose` negation)
+  is equivalent to passing just two.
+
+- The "commands" message types are messages showing each executed command along
+  with its arguments and working directory.
+
+- "`run` and `runpr` commands" are commands passed to the `run` and `runpr`
+  subcommands for execution.
+
+- "Operational commands" are miscellaneous commands run by `forall`, such as
+  `git commit` for `runpr` or `pre-commit autoupdate` for `pre-update`.
+
+- "Filter commands" are commands run in order to determine whether to operate
+  on a project.
 
 `forall list`
 -------------

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -116,9 +116,9 @@ impl CommandPlus {
             Ok(true)
         } else if self.keep_going {
             if let Some(code) = rc.code() {
-                log::error!("[{code}]");
+                error!("[{code}]");
             } else {
-                log::error!("[{rc}]");
+                error!("[{rc}]");
             }
             Ok(false)
         } else {

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -161,9 +161,7 @@ impl CommandPlus {
         }
     }
 
-    pub(crate) fn combine_stdout_stderr(
-        &mut self,
-    ) -> Result<(String, ExitStatus), CombinedCommandError> {
+    fn combine_stdout_stderr(&mut self) -> Result<(String, ExitStatus), CombinedCommandError> {
         logcmd(self, self.trace);
         // <https://stackoverflow.com/a/72831067/744178>
         let mut child = self

--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -17,7 +17,7 @@ impl Clean {
                     .quiet(opts.quiet())
                     .run()?;
             } else {
-                log::debug!("{}: already clean", p.name());
+                info!("{}: already clean", p.name());
             }
         }
         Ok(())

--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -1,3 +1,4 @@
+use crate::logging::logproject;
 use crate::project::Project;
 use crate::util::Options;
 use clap::Args;
@@ -10,7 +11,7 @@ impl Clean {
     pub(crate) fn run(self, opts: Options, projects: Vec<Project>) -> anyhow::Result<()> {
         for p in projects {
             if !p.readcmd("git", ["clean", "-dXn"])?.is_empty() {
-                boldln!("{}", p.name());
+                logproject(&p);
                 p.runcmd("git")
                     .args(["clean", "-dXf"])
                     .quiet(opts.quiet)

--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -16,6 +16,8 @@ impl Clean {
                     .args(["clean", "-dXf"])
                     .quiet(opts.quiet())
                     .run()?;
+            } else {
+                log::debug!("{}: already clean", p.name());
             }
         }
         Ok(())

--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -8,16 +8,13 @@ use clap::Args;
 pub(crate) struct Clean;
 
 impl Clean {
-    pub(crate) fn run(self, opts: Options, projects: Vec<Project>) -> anyhow::Result<()> {
+    pub(crate) fn run(self, _opts: Options, projects: Vec<Project>) -> anyhow::Result<()> {
         for p in projects {
             if !p.readcmd("git", ["clean", "-dXn"])?.is_empty() {
                 logproject(&p);
-                p.runcmd("git")
-                    .args(["clean", "-dXf"])
-                    .quiet(opts.quiet())
-                    .run()?;
+                p.runcmd("git").args(["clean", "-dXf"]).run()?;
             } else {
-                info!("{}: already clean", p.name());
+                debug!("{}: already clean", p.name());
             }
         }
         Ok(())

--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -14,7 +14,7 @@ impl Clean {
                 logproject(&p);
                 p.runcmd("git")
                     .args(["clean", "-dXf"])
-                    .quiet(opts.quiet)
+                    .quiet(opts.quiet())
                     .run()?;
             }
         }

--- a/src/commands/cloc.rs
+++ b/src/commands/cloc.rs
@@ -1,4 +1,5 @@
 use crate::cmd::CommandOutputError;
+use crate::logging::logfailures;
 use crate::project::{Language, Project};
 use crate::util::Options;
 use anyhow::Context;
@@ -16,7 +17,7 @@ impl Cloc {
             let srcs = p.source_paths()?;
             if srcs.is_empty() {
                 if opts.keep_going {
-                    errorln!("{}: Could not identify source files", p.name());
+                    log::error!("{}: Could not identify source files", p.name());
                     failures.push(p);
                     continue;
                 } else {
@@ -42,12 +43,7 @@ impl Cloc {
             let lines = data.for_language(p.language()).unwrap_or_default().code;
             println!("{lines:6} {}", p.name());
         }
-        if !failures.is_empty() {
-            boldln!("\nFailures:");
-            for p in failures {
-                println!("{}", p.name());
-            }
-        }
+        logfailures(failures);
         Ok(())
     }
 }

--- a/src/commands/cloc.rs
+++ b/src/commands/cloc.rs
@@ -17,7 +17,7 @@ impl Cloc {
             let srcs = p.source_paths()?;
             if srcs.is_empty() {
                 if opts.keep_going {
-                    log::error!("{}: Could not identify source files", p.name());
+                    error!("{}: Could not identify source files", p.name());
                     failures.push(p);
                     continue;
                 } else {

--- a/src/commands/gc.rs
+++ b/src/commands/gc.rs
@@ -1,3 +1,4 @@
+use crate::logging::logproject;
 use crate::project::Project;
 use crate::util::Options;
 use clap::Args;
@@ -9,7 +10,7 @@ pub(crate) struct Gc;
 impl Gc {
     pub(crate) fn run(self, opts: Options, projects: Vec<Project>) -> anyhow::Result<()> {
         for p in projects {
-            boldln!("{}", p.name());
+            logproject(&p);
             p.runcmd("git").arg("gc").quiet(opts.quiet).run()?;
         }
         Ok(())

--- a/src/commands/gc.rs
+++ b/src/commands/gc.rs
@@ -8,10 +8,10 @@ use clap::Args;
 pub(crate) struct Gc;
 
 impl Gc {
-    pub(crate) fn run(self, opts: Options, projects: Vec<Project>) -> anyhow::Result<()> {
+    pub(crate) fn run(self, _opts: Options, projects: Vec<Project>) -> anyhow::Result<()> {
         for p in projects {
             logproject(&p);
-            p.runcmd("git").arg("gc").quiet(opts.quiet()).run()?;
+            p.runcmd("git").arg("gc").run()?;
         }
         Ok(())
     }

--- a/src/commands/gc.rs
+++ b/src/commands/gc.rs
@@ -11,7 +11,7 @@ impl Gc {
     pub(crate) fn run(self, opts: Options, projects: Vec<Project>) -> anyhow::Result<()> {
         for p in projects {
             logproject(&p);
-            p.runcmd("git").arg("gc").quiet(opts.quiet).run()?;
+            p.runcmd("git").arg("gc").quiet(opts.quiet()).run()?;
         }
         Ok(())
     }

--- a/src/commands/preupdate.rs
+++ b/src/commands/preupdate.rs
@@ -1,4 +1,5 @@
 use crate::cmd::CommandError;
+use crate::logging::{logfailures, logproject};
 use crate::project::Project;
 use crate::util::Options;
 use clap::Args;
@@ -17,7 +18,7 @@ impl PreUpdate {
             if !p.dirpath().join(PRE_COMMIT_FILE).fs_err_try_exists()? {
                 continue;
             }
-            boldln!("{}", p.name());
+            logproject(&p);
             p.stash(opts.quiet)?;
             if !p
                 .runcmd("pre-commit")
@@ -62,12 +63,7 @@ impl PreUpdate {
                 Err(e) => return Err(e.into()),
             }
         }
-        if !failures.is_empty() {
-            boldln!("\nFailures:");
-            for p in failures {
-                println!("{}", p.name());
-            }
-        }
+        logfailures(failures);
         Ok(())
     }
 }

--- a/src/commands/preupdate.rs
+++ b/src/commands/preupdate.rs
@@ -19,11 +19,10 @@ impl PreUpdate {
                 continue;
             }
             logproject(&p);
-            p.stash(opts.quiet())?;
+            p.stash()?;
             if !p
                 .runcmd("pre-commit")
                 .arg("autoupdate")
-                .quiet(opts.quiet())
                 .keep_going(opts.keep_going)
                 .run()?
             {
@@ -32,7 +31,6 @@ impl PreUpdate {
             }
             p.runcmd("git").args(["add", PRE_COMMIT_FILE]).run()?;
             // TODO: Suppress the "[{returncode}]" output when this fails:
-            // TODO: Shouldn't this honor --quiet?
             p.runcmd("pre-commit")
                 .args(["run", "-a"])
                 .keep_going(true)
@@ -56,7 +54,6 @@ impl PreUpdate {
                     p.runcmd("git")
                         .args(["commit", "-m"])
                         .arg(format!("Autoupdate {PRE_COMMIT_FILE}"))
-                        .quiet(opts.quiet())
                         .keep_going(opts.keep_going)
                         .run()?;
                 }

--- a/src/commands/preupdate.rs
+++ b/src/commands/preupdate.rs
@@ -19,11 +19,11 @@ impl PreUpdate {
                 continue;
             }
             logproject(&p);
-            p.stash(opts.quiet)?;
+            p.stash(opts.quiet())?;
             if !p
                 .runcmd("pre-commit")
                 .arg("autoupdate")
-                .quiet(opts.quiet)
+                .quiet(opts.quiet())
                 .keep_going(opts.keep_going)
                 .run()?
             {
@@ -56,7 +56,7 @@ impl PreUpdate {
                     p.runcmd("git")
                         .args(["commit", "-m"])
                         .arg(format!("Autoupdate {PRE_COMMIT_FILE}"))
-                        .quiet(opts.quiet)
+                        .quiet(opts.quiet())
                         .keep_going(opts.keep_going)
                         .run()?;
                 }

--- a/src/commands/preupdate.rs
+++ b/src/commands/preupdate.rs
@@ -16,6 +16,7 @@ impl PreUpdate {
         let mut failures = Vec::new();
         for p in projects {
             if !p.dirpath().join(PRE_COMMIT_FILE).fs_err_try_exists()? {
+                debug!("{} does not use pre-commit; skipping", p.name());
                 continue;
             }
             logproject(&p);

--- a/src/commands/pull.rs
+++ b/src/commands/pull.rs
@@ -20,7 +20,7 @@ impl Pull {
             if !p
                 .runcmd("git")
                 .arg("pull")
-                .quiet(opts.quiet)
+                .quiet(opts.quiet())
                 .keep_going(opts.keep_going)
                 .run()?
             {

--- a/src/commands/pull.rs
+++ b/src/commands/pull.rs
@@ -14,6 +14,7 @@ impl Pull {
         let mut failures = Vec::new();
         for p in projects {
             if !p.has_github() {
+                debug!("{} does not have a GitHub repository; skipping", p.name());
                 continue;
             }
             logproject(&p);

--- a/src/commands/pull.rs
+++ b/src/commands/pull.rs
@@ -1,3 +1,4 @@
+use crate::logging::{logfailures, logproject};
 use crate::project::Project;
 use crate::util::Options;
 use clap::Args;
@@ -15,7 +16,7 @@ impl Pull {
             if !p.has_github() {
                 continue;
             }
-            boldln!("{}", p.name());
+            logproject(&p);
             if !p
                 .runcmd("git")
                 .arg("pull")
@@ -26,12 +27,7 @@ impl Pull {
                 failures.push(p);
             }
         }
-        if !failures.is_empty() {
-            boldln!("\nFailures:");
-            for p in failures {
-                println!("{}", p.name());
-            }
-        }
+        logfailures(failures);
         Ok(())
     }
 }

--- a/src/commands/pull.rs
+++ b/src/commands/pull.rs
@@ -20,7 +20,6 @@ impl Pull {
             if !p
                 .runcmd("git")
                 .arg("pull")
-                .quiet(opts.quiet())
                 .keep_going(opts.keep_going)
                 .run()?
             {

--- a/src/commands/push.rs
+++ b/src/commands/push.rs
@@ -15,6 +15,7 @@ impl Push {
         let mut failures = Vec::new();
         for p in projects {
             if !p.has_github() {
+                debug!("{} does not have a GitHub repository; skipping", p.name());
                 continue;
             }
             // TODO: If this fails, emit "{BOLD:name}\n{ERROR:[1]}" and handle

--- a/src/commands/push.rs
+++ b/src/commands/push.rs
@@ -28,7 +28,6 @@ impl Push {
                 if !p
                     .runcmd("git")
                     .arg("push")
-                    .quiet(opts.quiet())
                     .keep_going(opts.keep_going)
                     .run()?
                 {

--- a/src/commands/push.rs
+++ b/src/commands/push.rs
@@ -28,7 +28,7 @@ impl Push {
                 if !p
                     .runcmd("git")
                     .arg("push")
-                    .quiet(opts.quiet)
+                    .quiet(opts.quiet())
                     .keep_going(opts.keep_going)
                     .run()?
                 {

--- a/src/commands/push.rs
+++ b/src/commands/push.rs
@@ -1,3 +1,4 @@
+use crate::logging::{logfailures, logproject};
 use crate::project::Project;
 use crate::util::Options;
 use clap::Args;
@@ -23,7 +24,7 @@ impl Push {
                 ["rev-list", "--count", "--right-only", "@{upstream}...HEAD"],
             )?;
             if ahead.parse::<usize>().unwrap_or_default() > 0 {
-                boldln!("{}", p.name());
+                logproject(&p);
                 if !p
                     .runcmd("git")
                     .arg("push")
@@ -35,12 +36,7 @@ impl Push {
                 }
             }
         }
-        if !failures.is_empty() {
-            boldln!("\nFailures:");
-            for p in failures {
-                println!("{}", p.name());
-            }
-        }
+        logfailures(failures);
         Ok(())
     }
 }

--- a/src/commands/rsclean.rs
+++ b/src/commands/rsclean.rs
@@ -19,7 +19,7 @@ impl Rsclean {
             if !p
                 .runcmd("cargo")
                 .arg("clean")
-                .quiet(opts.quiet)
+                .quiet(opts.quiet())
                 .keep_going(opts.keep_going)
                 .run()?
             {

--- a/src/commands/rsclean.rs
+++ b/src/commands/rsclean.rs
@@ -1,3 +1,4 @@
+use crate::logging::{logfailures, logproject};
 use crate::project::{Language, Project};
 use crate::util::Options;
 use clap::Args;
@@ -14,7 +15,7 @@ impl Rsclean {
             if p.language() != Language::Rust || !p.dirpath().join("target").fs_err_try_exists()? {
                 continue;
             }
-            boldln!("{}", p.name());
+            logproject(&p);
             if !p
                 .runcmd("cargo")
                 .arg("clean")
@@ -25,12 +26,7 @@ impl Rsclean {
                 failures.push(p);
             }
         }
-        if !failures.is_empty() {
-            boldln!("\nFailures:");
-            for p in failures {
-                println!("{}", p.name());
-            }
-        }
+        logfailures(failures);
         Ok(())
     }
 }

--- a/src/commands/rsclean.rs
+++ b/src/commands/rsclean.rs
@@ -13,6 +13,10 @@ impl Rsclean {
         let mut failures = Vec::new();
         for p in projects {
             if p.language() != Language::Rust || !p.dirpath().join("target").fs_err_try_exists()? {
+                debug!(
+                    "{} is not a Rust project with a target/ directory; skipping",
+                    p.name()
+                );
                 continue;
             }
             logproject(&p);

--- a/src/commands/rsclean.rs
+++ b/src/commands/rsclean.rs
@@ -19,7 +19,6 @@ impl Rsclean {
             if !p
                 .runcmd("cargo")
                 .arg("clean")
-                .quiet(opts.quiet())
                 .keep_going(opts.keep_going)
                 .run()?
             {

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -24,7 +24,7 @@ impl Run {
         for p in projects {
             logproject(&p);
             if self.stash {
-                p.stash(opts.quiet())?;
+                p.stash()?;
             }
             if !runner.run(&p, opts)? {
                 failures.push(p);

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,3 +1,4 @@
+use crate::logging::{logfailures, logproject};
 use crate::project::Project;
 use crate::util::{Options, RunOpts, Runner};
 use clap::Args;
@@ -21,7 +22,7 @@ impl Run {
         let runner = Runner::try_from(self.run_opts)?;
         let mut failures = Vec::new();
         for p in projects {
-            boldln!("{}", p.name());
+            logproject(&p);
             if self.stash {
                 p.stash(opts.quiet)?;
             }
@@ -29,12 +30,7 @@ impl Run {
                 failures.push(p);
             }
         }
-        if !failures.is_empty() {
-            boldln!("\nFailures:");
-            for p in failures {
-                println!("{}", p.name());
-            }
-        }
+        logfailures(failures);
         Ok(())
     }
 }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -24,7 +24,7 @@ impl Run {
         for p in projects {
             logproject(&p);
             if self.stash {
-                p.stash(opts.quiet)?;
+                p.stash(opts.quiet())?;
             }
             if !runner.run(&p, opts)? {
                 failures.push(p);

--- a/src/commands/runpr.rs
+++ b/src/commands/runpr.rs
@@ -85,9 +85,11 @@ impl RunPr {
         let mut failures = Vec::new();
         for p in projects {
             let Some(ghrepo) = p.ghrepo() else {
+                log::debug!("{} does not have a GitHub repository; skipping", p.name());
                 continue;
             };
             if github.get_repository(ghrepo)?.archived {
+                log::debug!("Repository for {} is archived; skipping", p.name());
                 continue;
             }
             logproject(&p);
@@ -144,7 +146,7 @@ impl RunPr {
                     maintainer_can_modify: true,
                 },
             )?;
-            println!("{}", pr.html_url); // TODO: Improve?
+            println!("{}", pr.html_url); // TODO: Improve display?
             if !self.label.is_empty() || !self.soft_label.is_empty() {
                 let label_names = github
                     .get_label_names(ghrepo)?

--- a/src/commands/runpr.rs
+++ b/src/commands/runpr.rs
@@ -92,19 +92,22 @@ impl RunPr {
             }
             logproject(&p);
             let defbranch = p.default_branch()?;
-            p.stash(opts.quiet)?;
+            p.stash(opts.quiet())?;
             p.runcmd("git")
                 .arg("checkout")
                 .arg("-b")
                 .arg(&branch)
                 .arg(defbranch)
-                .quiet(opts.quiet)
+                .quiet(opts.quiet())
                 .run()?;
             if !runner.run(&p, opts)? {
                 failures.push(p);
                 continue;
             }
-            p.runcmd("git").args(["add", "."]).quiet(opts.quiet).run()?;
+            p.runcmd("git")
+                .args(["add", "."])
+                .quiet(opts.quiet())
+                .run()?;
             // XXX: When adding support for commands that commit, also check
             //      whether $branch is ahead of $defbranch.
             if !p.has_staged_changes()? {
@@ -112,24 +115,24 @@ impl RunPr {
                 p.runcmd("git")
                     .arg("checkout")
                     .arg(defbranch)
-                    .quiet(opts.quiet)
+                    .quiet(opts.quiet())
                     .run()?;
                 p.runcmd("git")
                     .args(["branch", "-d"])
                     .arg(&branch)
-                    .quiet(opts.quiet)
+                    .quiet(opts.quiet())
                     .run()?;
                 continue;
             }
             p.runcmd("git")
                 .args(["commit", "-m"])
                 .arg(&self.message)
-                .quiet(opts.quiet)
+                .quiet(opts.quiet())
                 .run()?;
             p.runcmd("git")
                 .args(["push", "--set-upstream", "origin"])
                 .arg(&branch)
-                .quiet(opts.quiet)
+                .quiet(opts.quiet())
                 .run()?;
             let pr = github.create_pull_request(
                 ghrepo,

--- a/src/commands/runpr.rs
+++ b/src/commands/runpr.rs
@@ -85,11 +85,11 @@ impl RunPr {
         let mut failures = Vec::new();
         for p in projects {
             let Some(ghrepo) = p.ghrepo() else {
-                log::debug!("{} does not have a GitHub repository; skipping", p.name());
+                debug!("{} does not have a GitHub repository; skipping", p.name());
                 continue;
             };
             if github.get_repository(ghrepo)?.archived {
-                log::debug!("Repository for {} is archived; skipping", p.name());
+                debug!("Repository for {} is archived; skipping", p.name());
                 continue;
             }
             logproject(&p);
@@ -113,7 +113,7 @@ impl RunPr {
             // XXX: When adding support for commands that commit, also check
             //      whether $branch is ahead of $defbranch.
             if !p.has_staged_changes()? {
-                log::info!("No changes");
+                info!("No changes");
                 p.runcmd("git")
                     .arg("checkout")
                     .arg(defbranch)
@@ -164,7 +164,7 @@ impl RunPr {
                                 description: None,
                             },
                         )?;
-                        log::info!("Created label {lbl:?} in {ghrepo}");
+                        info!("Created label {lbl:?} in {ghrepo}");
                     }
                     labels.push(lbl.as_str());
                 }

--- a/src/commands/runpr.rs
+++ b/src/commands/runpr.rs
@@ -94,47 +94,33 @@ impl RunPr {
             }
             logproject(&p);
             let defbranch = p.default_branch()?;
-            p.stash(opts.quiet())?;
+            p.stash()?;
             p.runcmd("git")
                 .arg("checkout")
                 .arg("-b")
                 .arg(&branch)
                 .arg(defbranch)
-                .quiet(opts.quiet())
                 .run()?;
             if !runner.run(&p, opts)? {
                 failures.push(p);
                 continue;
             }
-            p.runcmd("git")
-                .args(["add", "."])
-                .quiet(opts.quiet())
-                .run()?;
+            p.runcmd("git").args(["add", "."]).run()?;
             // XXX: When adding support for commands that commit, also check
             //      whether $branch is ahead of $defbranch.
             if !p.has_staged_changes()? {
                 info!("No changes");
-                p.runcmd("git")
-                    .arg("checkout")
-                    .arg(defbranch)
-                    .quiet(opts.quiet())
-                    .run()?;
-                p.runcmd("git")
-                    .args(["branch", "-d"])
-                    .arg(&branch)
-                    .quiet(opts.quiet())
-                    .run()?;
+                p.runcmd("git").arg("checkout").arg(defbranch).run()?;
+                p.runcmd("git").args(["branch", "-d"]).arg(&branch).run()?;
                 continue;
             }
             p.runcmd("git")
                 .args(["commit", "-m"])
                 .arg(&self.message)
-                .quiet(opts.quiet())
                 .run()?;
             p.runcmd("git")
                 .args(["push", "--set-upstream", "origin"])
                 .arg(&branch)
-                .quiet(opts.quiet())
                 .run()?;
             let pr = github.create_pull_request(
                 ghrepo,

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,4 +1,5 @@
 use crate::http_util::{get_next_link, StatusError};
+use crate::logging::logrequest;
 use anyhow::Context;
 use ghrepo::GHRepo;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -50,7 +51,7 @@ impl GitHub {
         url: Url,
         payload: Option<T>,
     ) -> anyhow::Result<Response> {
-        //log::debug!("{} {}", method, url);
+        logrequest(method, &url);
         let req = self.client.request_url(method, &url);
         let r = if let Some(p) = payload {
             req.send_json(p)

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,89 @@
+use crate::cmd::CommandPlus;
+use crate::project::Project;
+use anstream::AutoStream;
+use anstyle::{AnsiColor, Style};
+use log::{Level, LevelFilter};
+use std::io;
+
+static PROJECT_TARGET: &str = "forall::class::project";
+static COMMAND_TARGET: &str = "forall::class::command";
+static REQUEST_TARGET: &str = "forall::class::request";
+
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub(crate) enum Verbosity {
+    Quiet,
+    #[default]
+    Normal,
+    Verbose,
+}
+
+impl Verbosity {
+    fn level_filter(&self) -> LevelFilter {
+        match self {
+            Verbosity::Quiet => LevelFilter::Info,
+            Verbosity::Normal => LevelFilter::Info,
+            Verbosity::Verbose => LevelFilter::Trace,
+        }
+    }
+
+    fn command_filter(&self) -> LevelFilter {
+        match self {
+            Verbosity::Quiet => LevelFilter::Info,
+            Verbosity::Normal => LevelFilter::Debug,
+            Verbosity::Verbose => LevelFilter::Trace,
+        }
+    }
+
+    fn request_filter(&self) -> LevelFilter {
+        match self {
+            Verbosity::Quiet => LevelFilter::Info,
+            Verbosity::Normal => LevelFilter::Debug,
+            Verbosity::Verbose => LevelFilter::Trace,
+        }
+    }
+}
+
+pub(crate) fn init_logging(verbosity: Verbosity) {
+    let outstream: Box<dyn io::Write + Send> = Box::new(AutoStream::auto(io::stdout()));
+    fern::Dispatch::new()
+        .format(|out, message, record| {
+            use AnsiColor::*;
+            let (style, prefix) = match (record.level(), record.target()) {
+                (Level::Error, _) => (Style::new().fg_color(Some(Red.into())), ""),
+                (Level::Warn, _) => (Style::new().fg_color(Some(Yellow.into())), ""),
+                (Level::Info, t) if t == PROJECT_TARGET => (Style::new().bold(), ""),
+                (Level::Info, _) => (Style::new().fg_color(Some(Blue.into())), "> "),
+                (Level::Debug, _) => (Style::new().fg_color(Some(Cyan.into())), ""),
+                (Level::Trace, _) => (Style::new().fg_color(Some(Green.into())), ""),
+            };
+            out.finish(format_args!("{style}{prefix}{message}{style:#}"));
+        })
+        .level(LevelFilter::Info)
+        .level_for("forall", verbosity.level_filter())
+        .level_for(COMMAND_TARGET, verbosity.command_filter())
+        .level_for(REQUEST_TARGET, verbosity.request_filter())
+        .chain(outstream)
+        .apply()
+        .expect("no other logger should have been previously initialized");
+}
+
+pub(crate) fn logproject(p: &Project) {
+    log::info!(target: PROJECT_TARGET, "{}", p.name());
+}
+
+pub(crate) fn logcmd(cmd: &CommandPlus) {
+    log::debug!(target: COMMAND_TARGET, "+{}", cmd.cmdline());
+}
+
+pub(crate) fn logrequest(method: &str, url: &url::Url) {
+    log::debug!(target: REQUEST_TARGET, "{method} {url}");
+}
+
+pub(crate) fn logfailures(failures: Vec<Project>) {
+    if !failures.is_empty() {
+        anstream::println!("\n{bold}Failures:{bold:#}", bold = Style::new().bold());
+        for p in failures {
+            println!("{}", p.name());
+        }
+    }
+}

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -48,15 +48,15 @@ pub(crate) fn init_logging(verbosity: Verbosity) {
     fern::Dispatch::new()
         .format(|out, message, record| {
             use AnsiColor::*;
-            let (style, prefix) = match (record.level(), record.target()) {
-                (Level::Error, _) => (Style::new().fg_color(Some(Red.into())), ""),
-                (Level::Warn, _) => (Style::new().fg_color(Some(Yellow.into())), ""),
-                (Level::Info, t) if t == PROJECT_TARGET => (Style::new().bold(), ""),
-                (Level::Info, _) => (Style::new().fg_color(Some(Blue.into())), "> "),
-                (Level::Debug, _) => (Style::new().fg_color(Some(Cyan.into())), ""),
-                (Level::Trace, _) => (Style::new().fg_color(Some(Green.into())), ""),
+            let style = match (record.level(), record.target()) {
+                (Level::Error, _) => Style::new().fg_color(Some(Red.into())),
+                (Level::Warn, _) => Style::new().fg_color(Some(Yellow.into())),
+                (Level::Info, t) if t == PROJECT_TARGET => Style::new().bold(),
+                (Level::Info, _) => Style::new().fg_color(Some(Blue.into())),
+                (Level::Debug, _) => Style::new().fg_color(Some(Cyan.into())),
+                (Level::Trace, _) => Style::new().fg_color(Some(Green.into())),
             };
-            out.finish(format_args!("{style}{prefix}{message}{style:#}"));
+            out.finish(format_args!("{style}{message}{style:#}"));
         })
         .level(LevelFilter::Info)
         .level_for("forall", verbosity.level_filter())

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -11,6 +11,7 @@ static REQUEST_TARGET: &str = "forall::class::request";
 
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub(crate) enum Verbosity {
+    Quiet2,
     Quiet,
     #[default]
     Normal,
@@ -20,6 +21,7 @@ pub(crate) enum Verbosity {
 impl Verbosity {
     fn level_filter(&self) -> LevelFilter {
         match self {
+            Verbosity::Quiet2 => LevelFilter::Info,
             Verbosity::Quiet => LevelFilter::Info,
             Verbosity::Normal => LevelFilter::Info,
             Verbosity::Verbose => LevelFilter::Debug,
@@ -28,6 +30,7 @@ impl Verbosity {
 
     fn command_filter(&self) -> LevelFilter {
         match self {
+            Verbosity::Quiet2 => LevelFilter::Info,
             Verbosity::Quiet => LevelFilter::Info,
             Verbosity::Normal => LevelFilter::Debug,
             Verbosity::Verbose => LevelFilter::Trace,
@@ -36,6 +39,7 @@ impl Verbosity {
 
     fn request_filter(&self) -> LevelFilter {
         match self {
+            Verbosity::Quiet2 => LevelFilter::Info,
             Verbosity::Quiet => LevelFilter::Info,
             Verbosity::Normal => LevelFilter::Debug,
             Verbosity::Verbose => LevelFilter::Trace,

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -15,6 +15,7 @@ pub(crate) enum Verbosity {
     #[default]
     Normal,
     Verbose,
+    Verbose2,
 }
 
 impl Verbosity {
@@ -22,7 +23,8 @@ impl Verbosity {
         match self {
             Verbosity::Quiet => LevelFilter::Info,
             Verbosity::Normal => LevelFilter::Info,
-            Verbosity::Verbose => LevelFilter::Trace,
+            Verbosity::Verbose => LevelFilter::Debug,
+            Verbosity::Verbose2 => LevelFilter::Trace,
         }
     }
 
@@ -30,7 +32,8 @@ impl Verbosity {
         match self {
             Verbosity::Quiet => LevelFilter::Info,
             Verbosity::Normal => LevelFilter::Debug,
-            Verbosity::Verbose => LevelFilter::Trace,
+            Verbosity::Verbose => LevelFilter::Debug,
+            Verbosity::Verbose2 => LevelFilter::Trace,
         }
     }
 
@@ -39,6 +42,7 @@ impl Verbosity {
             Verbosity::Quiet => LevelFilter::Info,
             Verbosity::Normal => LevelFilter::Debug,
             Verbosity::Verbose => LevelFilter::Trace,
+            Verbosity::Verbose2 => LevelFilter::Trace,
         }
     }
 }
@@ -49,6 +53,7 @@ pub(crate) fn init_logging(verbosity: Verbosity) {
         .format(|out, message, record| {
             use AnsiColor::*;
             let style = match (record.level(), record.target()) {
+                (_, t) if t == COMMAND_TARGET => Style::new().fg_color(Some(Cyan.into())),
                 (Level::Error, _) => Style::new().fg_color(Some(Red.into())),
                 (Level::Warn, _) => Style::new().fg_color(Some(Yellow.into())),
                 (Level::Info, t) if t == PROJECT_TARGET => Style::new().bold(),
@@ -71,8 +76,12 @@ pub(crate) fn logproject(p: &Project) {
     log::info!(target: PROJECT_TARGET, "{}", p.name());
 }
 
-pub(crate) fn logcmd(cmd: &CommandPlus) {
-    log::debug!(target: COMMAND_TARGET, "+{}", cmd.cmdline());
+pub(crate) fn logcmd(cmd: &CommandPlus, trace: bool) {
+    if trace {
+        log::trace!(target: COMMAND_TARGET, "+{}", cmd.cmdline());
+    } else {
+        log::debug!(target: COMMAND_TARGET, "+{}", cmd.cmdline());
+    }
 }
 
 pub(crate) fn logrequest(method: &str, url: &url::Url) {

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -57,7 +57,7 @@ pub(crate) fn init_logging(verbosity: Verbosity) {
                 (Level::Error, _) => Style::new().fg_color(Some(Red.into())),
                 (Level::Warn, _) => Style::new().fg_color(Some(Yellow.into())),
                 (Level::Info, t) if t == PROJECT_TARGET => Style::new().bold(),
-                (Level::Info, _) => Style::new().fg_color(Some(Blue.into())),
+                (Level::Info, _) => Style::new().fg_color(Some(BrightBlue.into())),
                 (Level::Debug, _) => Style::new().fg_color(Some(Cyan.into())),
                 (Level::Trace, _) => Style::new().fg_color(Some(Green.into())),
             };

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -7,18 +7,20 @@ static VERBOSITY: OnceLock<Verbosity> = OnceLock::new();
 
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub(crate) enum Verbosity {
+    On,
     Quiet2,
     Quiet,
     #[default]
     Normal,
     Verbose,
+    Off,
 }
 
 pub(crate) fn init_logging(level: Verbosity) {
     let _ = VERBOSITY.set(level);
 }
 
-fn is_active(level: Verbosity) -> bool {
+pub(crate) fn is_active(level: Verbosity) -> bool {
     level <= VERBOSITY.get().copied().unwrap_or_default()
 }
 
@@ -30,12 +32,7 @@ pub(crate) fn logproject(p: &Project) {
     );
 }
 
-pub(crate) fn logcmd(cmd: &CommandPlus, trace: bool) {
-    let level = if trace {
-        Verbosity::Verbose
-    } else {
-        Verbosity::Normal
-    };
+pub(crate) fn logcmd(cmd: &CommandPlus, level: Verbosity) {
     if is_active(level) {
         anstream::eprintln!(
             "{style}+{line}{style:#}",
@@ -67,7 +64,7 @@ pub(crate) fn logfailures(failures: Vec<Project>) {
 macro_rules! error {
     ($($arg:tt)*) => {{
         $crate::logging::logln(
-            $crate::logging::Verbosity::Quiet2,
+            $crate::logging::Verbosity::On,
             anstyle::Style::new().fg_color(Some(anstyle::AnsiColor::Red.into())),
             format_args!($($arg)*)
         );

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -15,7 +15,6 @@ pub(crate) enum Verbosity {
     #[default]
     Normal,
     Verbose,
-    Verbose2,
 }
 
 impl Verbosity {
@@ -24,7 +23,6 @@ impl Verbosity {
             Verbosity::Quiet => LevelFilter::Info,
             Verbosity::Normal => LevelFilter::Info,
             Verbosity::Verbose => LevelFilter::Debug,
-            Verbosity::Verbose2 => LevelFilter::Trace,
         }
     }
 
@@ -32,8 +30,7 @@ impl Verbosity {
         match self {
             Verbosity::Quiet => LevelFilter::Info,
             Verbosity::Normal => LevelFilter::Debug,
-            Verbosity::Verbose => LevelFilter::Debug,
-            Verbosity::Verbose2 => LevelFilter::Trace,
+            Verbosity::Verbose => LevelFilter::Trace,
         }
     }
 
@@ -42,7 +39,6 @@ impl Verbosity {
             Verbosity::Quiet => LevelFilter::Info,
             Verbosity::Normal => LevelFilter::Debug,
             Verbosity::Verbose => LevelFilter::Trace,
-            Verbosity::Verbose2 => LevelFilter::Trace,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,14 @@
-#[macro_use]
-mod util;
-
 mod cmd;
 mod commands;
 mod finder;
 mod github;
 mod http_util;
+mod logging;
 mod project;
+mod util;
 use crate::commands::Command;
 use crate::finder::Finder;
+use crate::logging::init_logging;
 use crate::util::Options;
 use clap::Parser;
 
@@ -32,6 +32,7 @@ fn main() -> anyhow::Result<()> {
         finder,
         command,
     } = Arguments::parse();
+    init_logging(opts.verbosity());
     let projects = finder.findall()?;
     command.run(opts, projects)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,11 @@
+#[macro_use]
+mod logging;
+
 mod cmd;
 mod commands;
 mod finder;
 mod github;
 mod http_util;
-mod logging;
 mod project;
 mod util;
 use crate::commands::Command;

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -156,6 +156,7 @@ impl Project {
         Ok(self
             .runcmd("git")
             .args(["diff", "--cached", "--quiet"])
+            .trace(true)
             .status()?
             .code()
             == Some(1))
@@ -216,6 +217,7 @@ impl Project {
         CommandPlus::new(cmd)
             .args(args)
             .current_dir(&self.dirpath)
+            .trace(true)
             .check_output()
             .map(|s| s.trim().to_owned())
     }

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -1,6 +1,6 @@
 mod lang;
 pub(crate) use self::lang::*;
-use crate::cmd::{CommandError, CommandOutputError, CommandPlus};
+use crate::cmd::{CommandError, CommandKind, CommandOutputError, CommandPlus};
 use crate::util::get_ghrepo;
 use anyhow::Context;
 use cargo_metadata::{MetadataCommand, TargetKind};
@@ -156,22 +156,19 @@ impl Project {
         Ok(self
             .runcmd("git")
             .args(["diff", "--cached", "--quiet"])
-            .trace(true)
+            .kind(CommandKind::Filter)
             .status()?
             .code()
             == Some(1))
     }
 
-    pub(crate) fn stash(&self, quiet: bool) -> anyhow::Result<()> {
+    pub(crate) fn stash(&self) -> anyhow::Result<()> {
         // TODO: Should --ignore-submodules be set to something?
         if !self
             .readcmd("git", ["status", "--porcelain", "-unormal"])?
             .is_empty()
         {
-            self.runcmd("git")
-                .args(["stash", "-u"])
-                .quiet(quiet)
-                .run()?;
+            self.runcmd("git").args(["stash", "-u"]).run()?;
         }
         Ok(())
     }
@@ -217,7 +214,7 @@ impl Project {
         CommandPlus::new(cmd)
             .args(args)
             .current_dir(&self.dirpath)
-            .trace(true)
+            .kind(CommandKind::Filter)
             .check_output()
             .map(|s| s.trim().to_owned())
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -13,10 +13,11 @@ pub(crate) struct Options {
     #[arg(short, long, global = true)]
     pub(crate) keep_going: bool,
 
-    /// Suppress successful command output
+    /// Be less verbose
     #[arg(short, long, action = ArgAction::Count, global = true)]
     pub(crate) quiet: u8,
 
+    /// Be more verbose
     #[arg(short, long, global = true)]
     pub(crate) verbose: bool,
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -17,22 +17,19 @@ pub(crate) struct Options {
     #[arg(short, long, action = ArgAction::Count, global = true)]
     pub(crate) quiet: u8,
 
-    #[arg(short, long, action = ArgAction::Count, global = true, conflicts_with = "quiet")]
-    pub(crate) verbose: u8,
+    #[arg(short, long, global = true, conflicts_with = "quiet")]
+    pub(crate) verbose: bool,
 }
 
 impl Options {
     pub(crate) fn verbosity(&self) -> Verbosity {
         match (self.quiet, self.verbose) {
-            (0, 0) => Verbosity::Normal,
-            (_, 0) => Verbosity::Quiet,
-            (0, 1) => Verbosity::Verbose,
-            (0, _) => Verbosity::Verbose2,
+            (0, false) => Verbosity::Normal,
+            (_, false) => Verbosity::Quiet,
+            (0, true) => Verbosity::Verbose,
             // Work around <https://github.com/clap-rs/clap/issues/5899>:
-            (q, v) if q > v => Verbosity::Quiet,
-            (q, v) if q == v => Verbosity::Normal,
-            (q, v) if v == q + 1 => Verbosity::Verbose,
-            _ => Verbosity::Verbose2,
+            (1, true) => Verbosity::Normal,
+            (_, true) => Verbosity::Quiet,
         }
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-use crate::cmd::{CommandError, CommandOutputError, CommandPlus};
+use crate::cmd::{CommandError, CommandKind, CommandOutputError, CommandPlus};
 use crate::logging::Verbosity;
 use crate::project::Project;
 use clap::{ArgAction, Args};
@@ -30,14 +30,6 @@ impl Options {
             _ => Verbosity::Quiet2,
         }
     }
-
-    pub(crate) fn quiet(&self) -> bool {
-        self.verbosity() <= Verbosity::Quiet
-    }
-
-    pub(crate) fn quiet2(&self) -> bool {
-        self.verbosity() == Verbosity::Quiet
-    }
 }
 
 #[derive(Args, Clone, Debug, Eq, PartialEq)]
@@ -68,7 +60,7 @@ impl Runner {
     pub(crate) fn run(&self, p: &Project, opts: Options) -> Result<bool, CommandError> {
         p.runcmd(&self.command)
             .args(self.args.iter())
-            .quiet(opts.quiet2())
+            .kind(CommandKind::Run)
             .keep_going(opts.keep_going)
             .run()
     }
@@ -119,7 +111,7 @@ pub(crate) fn get_ghrepo(p: &Path) -> anyhow::Result<Option<GHRepo>> {
     match CommandPlus::new("git")
         .args(["remote", "get-url", "origin"])
         .current_dir(p)
-        .trace(true)
+        .kind(CommandKind::Filter)
         .stderr(std::process::Stdio::null())
         .check_output()
     {

--- a/src/util.rs
+++ b/src/util.rs
@@ -25,16 +25,22 @@ impl Options {
     pub(crate) fn verbosity(&self) -> Verbosity {
         match (self.quiet, self.verbose) {
             (0, false) => Verbosity::Normal,
-            (_, false) => Verbosity::Quiet,
+            (1, false) => Verbosity::Quiet,
+            (_, false) => Verbosity::Quiet2,
             (0, true) => Verbosity::Verbose,
             // Work around <https://github.com/clap-rs/clap/issues/5899>:
             (1, true) => Verbosity::Normal,
-            (_, true) => Verbosity::Quiet,
+            (2, true) => Verbosity::Quiet,
+            (_, true) => Verbosity::Quiet2,
         }
     }
 
     pub(crate) fn quiet(&self) -> bool {
-        self.quiet > 0
+        self.quiet - u8::from(self.verbose) > 0
+    }
+
+    pub(crate) fn quiet2(&self) -> bool {
+        self.quiet - u8::from(self.verbose) > 1
     }
 }
 
@@ -66,7 +72,7 @@ impl Runner {
     pub(crate) fn run(&self, p: &Project, opts: Options) -> Result<bool, CommandError> {
         p.runcmd(&self.command)
             .args(self.args.iter())
-            .quiet(opts.quiet())
+            .quiet(opts.quiet2())
             .keep_going(opts.keep_going)
             .run()
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -28,7 +28,11 @@ impl Options {
             (_, 0) => Verbosity::Quiet,
             (0, 1) => Verbosity::Verbose,
             (0, _) => Verbosity::Verbose2,
-            (_, _) => unreachable!(),
+            // Work around <https://github.com/clap-rs/clap/issues/5899>:
+            (q, v) if q > v => Verbosity::Quiet,
+            (q, v) if q == v => Verbosity::Normal,
+            (q, v) if v == q + 1 => Verbosity::Verbose,
+            _ => Verbosity::Verbose2,
         }
     }
 


### PR DESCRIPTION
Closes #24.
Closes #70.

To Do:

- [x] Add `--help` text to `--verbose`
- [x] Document `--verbose` in README
- [x] Update documentation of `--quiet` in `--help` and README
- ~Ensure that command lines for unsuccessful commands are logged at ERROR~ (Subsumed by #75)
- [x] Don't log filter commands unless `-vv` is given
- [x] `run` and `runpr`: Only suppress output from "main" commands when `-qq` is given (#70)
- [x] Log `run(pr)` and operational commands by default
- [x] Log filter commands on `-v`
    - Undo?
- [x] Remove `-vv`
- [x] Suppress INFO messages from `runpr` on `-q` and `-qq`
- [x] Replace `log` with a custom logging system

`--quiet` & `--verbose` semantics, log styles, and log stream details to aim for (Put this table in the README?):

| Content                           | `-qq` | `-q` |  —  | `-v` | Style | Stream |
| --------------------------------- | :---: | :--: | :-: | :--: | ----- | ------ |
| Project names                     | ✓     | ✓    | ✓   | ✓    | Bold  | stdout |
| Errors (incl. HTTP responses and captured failed output) | ✓     | ✓    | ✓   | ✓    | Red   | stderr |
| `run` and `runpr` commands        | ✗     | ✗    | ✓   | ✓    | Cyan  | stderr |
| `run` and `runpr` commands output | ✗     | ✓    | ✓   | ✓    | Plain | stdout |
| operational commands              | ✗     | ✗    | ✓   | ✓    | Cyan  | stderr |
| operational commands output       | ✗     | ✗    | ✓   | ✓    | Plain | stdout |
| filter commands                   | ✗     | ✗    | ✗   | ✓    | Cyan  | stderr |
| filter commands output            | ✗     | ✗    | ✗   | ✗    | —     | —      |
| HTTP requests                     | ✗     | ✗    | ✗   | ✓    | Cyan  | stderr |
| Messages about skipped projects   | ✗     | ✗    | ✗   | ✓    | Yellow | stderr |
| `runpr`: "No changes"             | ✗     | ✗    | ✓   | ✓    | Yellow | stderr |
| `runpr`: "Created label ..."      | ✗     | ✗    | ✓   | ✓    | Yellow | stderr |